### PR TITLE
Multi-series: Missing data name in fake data generator

### DIFF
--- a/examples/multiseries/parquet/gen_parquet_fake.py
+++ b/examples/multiseries/parquet/gen_parquet_fake.py
@@ -31,7 +31,7 @@ def generate_batch_data(num_rows, out_file):
         'name': [fake.name() for _ in range(num_rows)],
         'name-dup': [fake.name() for _ in range(num_rows)],
         'age': [random.randint(18, 70) for _ in range(num_rows)],
-        '': [fake.zipcode() for _ in range(num_rows)],
+        'zipcode': [fake.zipcode() for _ in range(num_rows)],
         'state': [fake.state() for _ in range(num_rows)],
         'job': [fake.job() for _ in range(num_rows)],
     }


### PR DESCRIPTION
A bug in `examples/multiseries/parquet/gen_parquet_fake.py` committed to the previous commit accidentally... 